### PR TITLE
Added Ability Score and Modifier class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
       "Components\\Race\\Dwarf\\": "src/components/Race/Dwarf",
       "Components\\CharacterClass\\": "src/components/CharacterClass",
       "Components\\CharacterClass\\Fighter\\": "src/components/CharacterClass/Fighter",
-      "Components\\CharacterClass\\Bard\\": "src/components/CharacterClass/Bard"
+      "Components\\CharacterClass\\Bard\\": "src/components/CharacterClass/Bard",
+      "Components\\Abilities\\": "src/components/Abilities"
     }
   },
   "autoload-dev": {

--- a/src/components/Abilities/Abilities.php
+++ b/src/components/Abilities/Abilities.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Components\Abilities;
+
+require_once(__DIR__ . '/../../../vendor/autoload.php');
+
+class Abilities {
+  // Ability score
+  protected int $strengthScore;
+  protected int $dexterityScore;
+  protected int $constitutionScore;
+  protected int $intelligenceScore;
+  protected int $wisdomScore;
+  protected int $charismaScore;
+
+  public function __construct($strengthScore, $dexterityScore, $constitutionScore, $intelligenceScore, $wisdomScore, $charismaScore) {
+    $this->strengthScore = $strengthScore;
+    $this->dexterityScore = $dexterityScore;
+    $this->constitutionScore = $constitutionScore;
+    $this->intelligenceScore = $intelligenceScore;
+    $this->wisdomScore = $wisdomScore;
+    $this->charismaScore = $charismaScore;
+  }
+
+  // ----------------------------------------------------------------
+  // Ability Score Methods
+
+  public function getStrengthScore(): int {
+    return $this->strengthScore;
+  }
+
+  public function getDexterityScore(): int {
+    return $this->dexterityScore;
+  }
+
+  public function getConstitutionScore(): int {
+    return $this->constitutionScore;
+  }
+
+  public function getIntelligenceScore(): int {
+    return $this->intelligenceScore;
+  }
+
+  public function getWisdomScore(): int {
+    return $this->wisdomScore;
+  }
+  
+  public function getCharismaScore(): int {
+    return $this->charismaScore;
+  }
+
+  // ----------------------------------------------------------------
+  // Ability Modifier Methods
+
+  public function getStrengthModifier(): int {
+    return $this->getModiferFromScore($this->strengthScore);
+  }
+
+  public function getDexterityModifier(): int {
+    return $this->getModiferFromScore($this->dexterityScore);
+  }
+
+  public function getConstitutionModifier(): int {
+    return $this->getModiferFromScore($this->constitutionScore);
+  }
+
+  public function getIntelligenceModifier(): int {
+    return $this->getModiferFromScore($this->intelligenceScore);
+  }
+
+  public function getWisdomModifier(): int {
+    return $this->getModiferFromScore($this->wisdomScore);
+  }
+
+  public function getCharismaModifier(): int {
+    return $this->getModiferFromScore($this->charismaScore);
+  }
+
+  private function getModiferFromScore(int $score): int {
+    return floor(($score - 10) / 2);
+  }
+}

--- a/tests/unit/AbilitiesTest.php
+++ b/tests/unit/AbilitiesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Components\Test\Unit;
+
+require_once(__DIR__ . '/../../vendor/autoload.php');
+
+use PHPUnit\Framework\TestCase;
+use Components\Abilities\Abilities;
+
+class AbilitiesTest extends TestCase {
+  protected Abilities $testAbilities;
+  protected array $testAbilityScores = array(
+    'STR' => ['score' => 14, 'mod' =>  2],
+    'DEX' => ['score' => 13, 'mod' =>  1],
+    'CON' => ['score' => 15, 'mod' =>  2],
+    'INT' => ['score' => 10, 'mod' =>  0],
+    'WIS' => ['score' =>  8, 'mod' => -1],
+    'CHA' => ['score' => 12, 'mod' =>  1]
+  );
+
+  public function setUp(): void {
+    $this->testAbilities = new Abilities(
+      $this->testAbilityScores['STR']['score'],
+      $this->testAbilityScores['DEX']['score'],
+      $this->testAbilityScores['CON']['score'],
+      $this->testAbilityScores['INT']['score'],
+      $this->testAbilityScores['WIS']['score'],
+      $this->testAbilityScores['CHA']['score']
+    );
+  }
+  // ----------------------------------------------------------------
+  public function testIfCanGetStrengthAbilityScore(): void {
+    $this->assertEquals($this->testAbilities->getStrengthScore(), $this->testAbilityScores['STR']['score']);
+  }
+
+  public function testIfCanGetDexterityAbilityScore(): void {
+    $this->assertEquals($this->testAbilities->getDexterityScore(), $this->testAbilityScores['DEX']['score']);
+  }
+
+  public function testIfCanGetConstitutionAbilityScore(): void {
+    $this->assertEquals($this->testAbilities->getConstitutionScore(), $this->testAbilityScores['CON']['score']);
+  }
+
+  public function testIfCanGetIntelligenceAbilityScore(): void {
+    $this->assertEquals($this->testAbilities->getIntelligenceScore(), $this->testAbilityScores['INT']['score']);
+  }
+
+  public function testIfCanGetWisdomAbilityScore(): void {
+    $this->assertEquals($this->testAbilities->getWisdomScore(), $this->testAbilityScores['WIS']['score']);
+  }
+
+  public function testIfCanGetCharismaAbilityScore(): void {
+    $this->assertEquals($this->testAbilities->getCharismaScore(), $this->testAbilityScores['CHA']['score']);
+  }
+
+  // ----------------------------------------------------------------
+
+  public function testIfCanGetStrengthModifier(): void {
+    $this->assertEquals($this->testAbilities->getStrengthModifier(), $this->testAbilityScores['STR']['mod']);
+  }
+
+  public function testIfCanGetDexterityModifier(): void {
+    $this->assertEquals($this->testAbilities->getDexterityModifier(), $this->testAbilityScores['DEX']['mod']);
+  }
+
+  public function testIfCanGetConstitutionModifier(): void {
+    $this->assertEquals($this->testAbilities->getConstitutionModifier(), $this->testAbilityScores['CON']['mod']);
+  }
+
+  public function testIfCanGetIntelligenceModifier(): void {
+    $this->assertEquals($this->testAbilities->getIntelligenceModifier(), $this->testAbilityScores['INT']['mod']);
+  }
+
+  public function testIfCanGetWisdomModifier(): void {
+    $this->assertEquals($this->testAbilities->getWisdomModifier(), $this->testAbilityScores['WIS']['mod']);
+  }
+
+  public function testIfCanGetCharismaModifier(): void {
+    $this->assertEquals($this->testAbilities->getCharismaModifier(), $this->testAbilityScores['CHA']['mod']);
+  }
+
+  // ----------------------------------------------------------------
+  public function tearDown(): void {
+    unset($this->testAbilities);
+  }
+}


### PR DESCRIPTION
Another essential part of the game, ability scores. I decided to create a class to manage all the responsibilities the ability scores are supposed to do. The ability scores themselves are going to be added to the playerCharacters class, allowing the characters themselves to reference the ability scores and their modifiers directly. So far I've only done the scores and the modifiers. Still need a way to manage the skills that are associated with it, the saving throw and any attacks that are tied to the scores (Spellcasting is goign to be a nightmare).

Also, I'm really not sure if creating a whole bunch of getters for the ability scores is a good design. But for now, I'll keep it like this and refactor it if it get's too annoying.