### PR TITLE
Moved Levels functionality to CharacterClass components

### DIFF
--- a/src/components/CharacterClass/CharacterClass.php
+++ b/src/components/CharacterClass/CharacterClass.php
@@ -2,11 +2,24 @@
 
 namespace Components\CharacterClass;
 
-
 require_once(__DIR__ . '/../../../vendor/autoload.php');
+
+use Components\Level\Level;
 
 abstract class CharacterClass {
   // Default properties
 
-  private string $name;
+  private Level $level;
+
+  public function __construct(int $startingExperience = 0) {
+    $this->setLevel(new Level($startingExperience));
+  }
+
+  public function setLevel(Level $level) {
+    $this->level = $level;
+  }
+
+  public function getLevel() {
+    return $this->level;
+  }
 }

--- a/src/components/PlayerCharacter/PlayerCharacter.php
+++ b/src/components/PlayerCharacter/PlayerCharacter.php
@@ -6,7 +6,6 @@ use Components\Defaults\Defaults;
 use Components\Race\Race;
 use Components\CharacterClass\CharacterClass;
 use Components\Abilities\Abilities;
-use Components\Level\Level;
 
 require_once(__DIR__ . '/../../../vendor/autoload.php');
 
@@ -17,7 +16,6 @@ class PlayerCharacter {
   private Race $race;
   private array $classes;
   private Abilities $abilities;
-  private Level $level;
 
   // Character basic properties
   private int $age;
@@ -54,37 +52,41 @@ class PlayerCharacter {
   // ----------------------------------------------------------------
   // Class Methods
 
-  public function setClass(CharacterClass $newClass): void {
+  public function setClass(CharacterClass $newClass): PlayerCharacter {
     $this->classes[] = $newClass;
+    return $this;
   }
 
   public function getAllClasses(): array {
     return $this->classes;
   }
 
-  public function getClassByIndex(int $classIdx = 1): CharacterClass {
+  public function getClassByIndex(int $classIdx = 0): CharacterClass {
     return $this->classes[$classIdx];
   }
 
   // ----------------------------------------------------------------
   // Basic Properties methods
 
-  public function setAge(int $age) {
+  public function setAge(int $age): PlayerCharacter {
     $this->age = $age;
+    return $this
   }
   public function getAge(): int {
     return $this->age;
   }
 
-  public function setHeight(float $height) {
+  public function setHeight(float $height): PlayerCharacter{
     $this->height = $height;
+    return $this;
   }
   public function getHeight(): float {
     return $this->height;
   }
 
-  public function setWeight(float $weight) {
+  public function setWeight(float $weight): PlayerCharacter {
     $this->weight = $weight;
+    return $this;
   }
   public function getWeight() {
     return $this->weight;
@@ -92,22 +94,13 @@ class PlayerCharacter {
 
   // ----------------------------------------------------------------
   // Abilities Methods
-  public function setAbilities(Abilities $abilities) {
+  public function setAbilities(Abilities $abilities): PlayerCharacter {
     $this->abilities = $abilities;
+    return $this;
   }
 
   public function getAbilities() {
     return $this->abilities;
-  }
-
-  // ----------------------------------------------------------------
-  // Level Methods
-  public function setLevel(Level $level) {
-    $this->level = $level;
-  }
-
-  public function getLevel() {
-    return $this->level;
   }
 
   // ----------------------------------------------------------------

--- a/tests/integration/CharacterClassLevelTest.php
+++ b/tests/integration/CharacterClassLevelTest.php
@@ -1,0 +1,35 @@
+<?php 
+
+namespace Components\Test\Integration;
+
+require_once(__DIR__.'/../../vendor/autoload.php');
+
+use PHPUnit\Framework\TestCase;
+use Components\CharacterClass\Bard\Bard;
+use Components\Level\Level;
+
+class CharacterClassLevelTest extends TestCase {
+  protected Bard $testCharacterClass;
+  protected Level $testLevel;
+
+  protected int $testExp = 2800;
+  
+  public function setUp(): void {
+    $this->testLevel = new Level($this->testExp);
+    $this->testCharacterClass = new Bard();
+    $this->testCharacterClass->setLevel($this->testLevel);
+  }
+
+  public function testIfCanGetLevelFromCharacterClass(): void {
+    $this->assertEquals($this->testLevel->getCurrentLevel(), $this->testCharacterClass->getLevel()->getCurrentLevel());
+  }
+
+  public function testIfCanGetProficiencyBonusFromCharacterClass(): void {
+    $this->assertEquals($this->testLevel->getCurrentProficiencyBonus(), $this->testCharacterClass->getLevel()->getCurrentProficiencyBonus());
+  }
+
+  public function tearDown(): void {
+    unset($this->testCharacterClass);
+    unset($this->testLevel);
+  }
+}

--- a/tests/integration/PlayerCharacterLevelTest.php
+++ b/tests/integration/PlayerCharacterLevelTest.php
@@ -5,8 +5,10 @@ namespace Components\Test\Integration;
 
 require_once(__DIR__.'/../../vendor/autoload.php');
 
+use Components\CharacterClass\Bard\Bard as BardBard;
 use PHPUnit\Framework\TestCase;
 use Components\PlayerCharacter\PlayerCharacter;
+use Components\CharacterClass\Bard\Bard;
 use Components\Level\Level;
 
 class PlayerCharacterLevelTest extends TestCase {
@@ -14,22 +16,25 @@ class PlayerCharacterLevelTest extends TestCase {
   protected string $playerName = 'John Smith';
   protected string $characterName = 'Sir Arthas';
 
+  protected Bard $characterClass;
+
   protected Level $testLevel;
   protected int $testExp = 10000;
 
   public function setUp(): void {
     $this->testPlayerCharacter = new PlayerCharacter($this->playerName, $this->characterName);
+    $this->characterClass = new Bard($this->testExp);
     $this->testLevel = new Level($this->testExp);
   }
   
   public function testIfCanGetPlayerCharacterLevel(): void {
-    $this->testPlayerCharacter->setLevel($this->testLevel);
-    $this->assertEquals($this->testLevel->getCurrentLevel(), $this->testPlayerCharacter->getLevel()->getCurrentLevel());
+    $this->testPlayerCharacter->setClass($this->characterClass)->getClassByIndex()->setLevel($this->testLevel);
+    $this->assertEquals($this->testLevel->getCurrentLevel(), $this->testPlayerCharacter->getClassByIndex()->getLevel()->getCurrentLevel());
   }
 
   public function testIfCanGetPlayerCharacterProficiencyBonus(): void {
-    $this->testPlayerCharacter->setLevel($this->testLevel);
-    $this->assertEquals($this->testLevel->getCurrentProficiencyBonus(), $this->testPlayerCharacter->getLevel()->getCurrentProficiencyBonus());
+    $this->testPlayerCharacter->setClass($this->characterClass)->getClassByIndex()->setLevel($this->testLevel);
+    $this->assertEquals($this->testLevel->getCurrentProficiencyBonus(), $this->testPlayerCharacter->getClassByIndex()->getLevel()->getCurrentProficiencyBonus());
   }
 
   public function tearDown(): void {


### PR DESCRIPTION
In D&D, the levels of a character can be tied to the class that the character has. It's also possible to multi-class, meaning picking two or more classes for their character. I moved the levels functionality so that each class can track it's own Level and retrieve the proficiency bonus based on the level of that particular class. There's a few more details to iron out, like how will the experience points be allocated, how do we track different experience points in three different classes? etc.